### PR TITLE
Fixed tasks loop runner!

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -16,12 +16,12 @@ bot = commands.Bot(command_prefix="/", intents=discord.Intents.all())
 
 activities = [
     discord.Game(name="MW3", platform="PS5")
-    discord.Game(name="FIFA 23", platform="XBOX")
-    discord.Game(name="Warzone")
-    discord.Watching(name="The Crow")
-    discord.Watching(name="Over the server")
-    discord.Listening(name="Lofi Beats")
-    discord.Listening(name="The Nights")
+#    discord.Game(name="FIFA 23", platform="XBOX")
+#    discord.Game(name="Warzone")
+#    discord.Watching(name="The Crow")
+#    discord.Watching(name="Over the server")
+#    discord.Listening(name="Lofi Beats")
+#    discord.Listening(name="The Nights")
         ]
 
 # Load cogs
@@ -37,11 +37,12 @@ async def load_cogs():
 #    await bot.load_extension('cogs.challenges')
 
 # Shuffle events here
-@tasks.loop(minutes=60) # 1hr
+@tasks.loop(minutes=30) # 30minutes
 async def change_activity():
     current_activity = random.choice(activities)
     await bot.change_presence(status=discord.Status.dnd, activity=current_activity)
     print(f"Bot statues updated to: {current_activity.name} ({current_activity.type.name})")
+
 
 @bot.event
 async def on_ready():

--- a/bot.py
+++ b/bot.py
@@ -37,7 +37,7 @@ async def load_cogs():
 #    await bot.load_extension('cogs.challenges')
 
 # Shuffle events here
-@tasks.loop(minutes=60)
+@tasks.loop(minutes=60) # 1hr
 async def change_activity():
     current_activity = random.choice(activities)
     await bot.change_presence(status=discord.Status.dnd, activity=current_activity)
@@ -56,7 +56,7 @@ async def on_ready():
     invisible
     online which is default without the line
     """
-    await bot.change_presence(status=discord.Status.dnd, activity=discord.Game(name="MW3"))
+    change_activity.start() # call change activity function
 
     # custom script end
     await bot.tree.sync()

--- a/bot.py
+++ b/bot.py
@@ -15,13 +15,13 @@ intents.message_content = True
 bot = commands.Bot(command_prefix="/", intents=discord.Intents.all())
 
 activities = [
-    discord.Activity(type=discord.ActivityType.playing, name="MW3")
-    discord.Activity(type=discord.ActivityType.playing, name="FIFA 23")
-    discord.Activity(type=discord.ActivityType.playing, name="Warzone")
-    discord.Activity(type=discord.ActivityType.watching, name="The Crow")
-    discord.Activity(type=discord.ActivityType.watching, name="Over the server")
-    discord.Activity(type=discord.ActivityType.listening, name="Lofi Beats")
-    discord.Activity(type=discord.ActivityType.listening, name="The Nights")
+    discord.Game(name="MW3", platform="PS5")
+    discord.Game(name="FIFA 23", platform="XBOX")
+    discord.Game(name="Warzone")
+    discord.Watching(name="The Crow")
+    discord.Watching(name="Over the server")
+    discord.Listening(name="Lofi Beats")
+    discord.Listening(name="The Nights")
         ]
 
 # Load cogs

--- a/bot.py
+++ b/bot.py
@@ -37,7 +37,7 @@ async def load_cogs():
 #    await bot.load_extension('cogs.challenges')
 
 # Shuffle events here
-@tasks.loop(minutes=30) # 30minutes
+@discord.ext.tasks.loop(minutes=30) # 30minutes
 async def change_activity():
     current_activity = random.choice(activities)
     await bot.change_presence(status=discord.Status.dnd, activity=current_activity)

--- a/bot.py
+++ b/bot.py
@@ -3,9 +3,10 @@ Main Entry point for shaheen bot that loads the cogs
 and boot the bot
 """
 import discord
-from discord.ext import commands
+from discord.ext import commands, tasks
 import os
 from dotenv import load_dotenv
+import random
 
 load_dotenv()
 
@@ -37,7 +38,7 @@ async def load_cogs():
 #    await bot.load_extension('cogs.challenges')
 
 # Shuffle events here
-@discord.ext.tasks.loop(minutes=30) # 30minutes
+@tasks.loop(minutes=30) # 30minutes
 async def change_activity():
     current_activity = random.choice(activities)
     await bot.change_presence(status=discord.Status.dnd, activity=current_activity)

--- a/bot.py
+++ b/bot.py
@@ -36,6 +36,12 @@ async def load_cogs():
     await bot.load_extension('cogs.readme')
 #    await bot.load_extension('cogs.challenges')
 
+# Shuffle events here
+@tasks.loop(minutes=60)
+async def change_activity():
+    current_activity = random.choice(activities)
+    await bot.change_presence(status=discord.Status.dnd, activity=current_activity)
+    print(f"Bot statues updated to: {current_activity.name} ({current_activity.type.name})")
 
 @bot.event
 async def on_ready():


### PR DESCRIPTION
- fixed: tasks.loop decorator by importing tasks from discord.ext
this pr fixed:
1. the nameerror that throws up when using the @tasks.loop decorator
it was solved by importing
* `tasks` from `discord.ext`
so this pr is implementing a list of activities that shaheen will be looping from and picking random every 30mins
